### PR TITLE
Fix wrong argument name: float -> framerate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Softcam library will be documented in this file.
 
+### [Unreleased]
+- Fixed wrong argument name in the python_binding example. [#16](https://github.com/tshino/softcam/pull/16)
+
+
 ### [1.4] - 2022-12-18
 - Added Python binding of this library. [#12](https://github.com/tshino/softcam/issues/12)
 - Improved error handling.

--- a/examples/python_binding/python_binding.cpp
+++ b/examples/python_binding/python_binding.cpp
@@ -94,7 +94,7 @@ PYBIND11_MODULE(softcam, m) {
             py::init<int, int, float>(),
             py::arg("width"),
             py::arg("height"),
-            py::arg("float") = 60.0f
+            py::arg("framerate") = 60.0f
         )
         .def(
             "delete",


### PR DESCRIPTION
```
softcam.camera(width, height, float)
```
-->
```
softcam.camera(width, height, framerate)
```