### PR TITLE
Add pushd/popd to installer BATs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Softcam library will be documented in this file.
 
 ### [Unreleased]
 - Updated solution file version from Visual Studio 2019 to Visual Studio 2022. [#45](https://github.com/tshino/softcam/pull/45)
+- Added `pushd`/`popd` to example installer BAT files to work correctly even if launched from another directory. [#48](https://github.com/tshino/softcam/pull/48)
 
 ### [1.7] - 2023-12-02
 - Bumped NuGet package version of Google Test.

--- a/examples/softcam_installer/RegisterSoftcam.bat
+++ b/examples/softcam_installer/RegisterSoftcam.bat
@@ -1,5 +1,6 @@
 @echo off
 
+pushd %~dp0
 set INSTALLER=x64\Release\softcam_installer.exe
 set TARGET=..\..\dist\bin\x64\softcam.dll
 
@@ -20,4 +21,5 @@ if %ERRORLEVEL% == 0 (
   echo The process has been canceled or failed.
   echo.
 )
+popd
 pause

--- a/examples/softcam_installer/RegisterSoftcam32.bat
+++ b/examples/softcam_installer/RegisterSoftcam32.bat
@@ -1,5 +1,6 @@
 @echo off
 
+pushd %~dp0
 set INSTALLER=Win32\Release\softcam_installer.exe
 set TARGET=..\..\dist\bin\Win32\softcam.dll
 
@@ -20,4 +21,5 @@ if %ERRORLEVEL% == 0 (
   echo The process has been canceled or failed.
   echo.
 )
+popd
 pause

--- a/examples/softcam_installer/UnregisterSoftcam.bat
+++ b/examples/softcam_installer/UnregisterSoftcam.bat
@@ -1,5 +1,6 @@
 @echo off
 
+pushd %~dp0
 set INSTALLER=x64\Release\softcam_installer.exe
 set TARGET=..\..\dist\bin\x64\softcam.dll
 
@@ -20,4 +21,5 @@ if %ERRORLEVEL% == 0 (
   echo The process has been canceled or failed.
   echo.
 )
+popd
 pause

--- a/examples/softcam_installer/UnregisterSoftcam32.bat
+++ b/examples/softcam_installer/UnregisterSoftcam32.bat
@@ -1,5 +1,6 @@
 @echo off
 
+pushd %~dp0
 set INSTALLER=Win32\Release\softcam_installer.exe
 set TARGET=..\..\dist\bin\Win32\softcam.dll
 
@@ -20,4 +21,5 @@ if %ERRORLEVEL% == 0 (
   echo The process has been canceled or failed.
   echo.
 )
+popd
 pause


### PR DESCRIPTION
The four batch files to install/uninstall 64-bit/32-bit version of softcam.dll were not working if they launched with the working directory other than the directory where they are. Because they use relative paths to specify DLL/EXE.

This PR fixes it by adding `pushd` and `popd`.
