### PR TITLE
Add 'scIsConnected()' method to API to make application connection waiting more flexible.

### DIFF
--- a/src/softcam/softcam.cpp
+++ b/src/softcam/softcam.cpp
@@ -176,3 +176,8 @@ extern "C" bool     scWaitForConnection(scCamera camera, float timeout)
 {
     return softcam::sender::WaitForConnection(camera, timeout);
 }
+
+extern "C" bool     scIsConnected(scCamera camera)
+{
+	return softcam::sender::IsConnected(camera);
+}

--- a/src/softcam/softcam.def
+++ b/src/softcam/softcam.def
@@ -8,3 +8,4 @@ EXPORTS
             scDeleteCamera
             scSendFrame
             scWaitForConnection
+            scIsConnected

--- a/src/softcam/softcam.h
+++ b/src/softcam/softcam.h
@@ -74,4 +74,14 @@ extern "C"
         this function returns `false`.
     */
     bool        SOFTCAM_API scWaitForConnection(scCamera camera, float timeout = 0.0f);
+
+    /*
+        This function reports if an application is connected to the specified
+        virtual camera.
+
+        This function returns `true` if the virtual camera has ever been
+        accessed by an application before this function returns. Otherwise,
+        this function returns `false`.
+    */
+	bool        SOFTCAM_API scIsConnected(scCamera camera);
 }

--- a/src/softcamcore/SenderAPI.cpp
+++ b/src/softcamcore/SenderAPI.cpp
@@ -111,5 +111,15 @@ bool            WaitForConnection(CameraHandle camera, float timeout)
     return false;
 }
 
+bool            IsConnected(CameraHandle camera)
+{
+	Camera* target = static_cast<Camera*>(camera);
+	if (target && s_camera.load() == target)
+	{
+		return target->m_frame_buffer.connected();
+	}
+	return false;
+}
+
 } //namespace sender
 } //namespace softcam

--- a/src/softcamcore/SenderAPI.h
+++ b/src/softcamcore/SenderAPI.h
@@ -10,6 +10,7 @@ CameraHandle    CreateCamera(int width, int height, float framerate = 60.0f);
 void            DeleteCamera(CameraHandle camera);
 void            SendFrame(CameraHandle camera, const void* image_bits);
 bool            WaitForConnection(CameraHandle camera, float timeout = 0.0f);
+bool            IsConnected(CameraHandle camera);
 
 } //namespace sender
 } //namespace softcam


### PR DESCRIPTION
Making my C# app I found it more comfortable to use the flag instead of the stopper method.