### PR TITLE
Remove coinitilise failure checks

### DIFF
--- a/src/baseclasses/dllsetup.cpp
+++ b/src/baseclasses/dllsetup.cpp
@@ -424,7 +424,6 @@ AMovieDllRegisterServer2( BOOL bRegister )
     //
     DbgLog((LOG_TRACE, 2, TEXT("- CoInitialize")));
     hr = CoInitialize( (LPVOID)NULL );
-    ASSERT( SUCCEEDED(hr) );
 
     // get hold of IFilterMapper2
     //

--- a/src/softcam/softcam.cpp
+++ b/src/softcam/softcam.cpp
@@ -81,9 +81,6 @@ STDAPI DllRegisterServer()
     }
     hr = CoInitialize(nullptr);
     if (FAILED(hr))
-    {
-        return hr;
-    }
     do
     {
         IFilterMapper2 *pFM2 = nullptr;


### PR DESCRIPTION
## Summary
Registering the softcam dll from a C# application fails because CoInitilize is implicitly called from the dotnet runtime. So calling it again from within the softcam registering method will return a S_False result. Since the S_False result only shows that *"The COM library is already initialized on this thread."* I think it is safe to remove the checks for it.

